### PR TITLE
fix or add some links to sibling docs in other_blockchains

### DIFF
--- a/other_blockchains/Emin_Gun_Sirer.md
+++ b/other_blockchains/Emin_Gun_Sirer.md
@@ -93,7 +93,7 @@ Emin in July 2018
 
 Avalanche consensus is for the altcoin Emin is planning to sell.
 
-my review of avalanche: https://github.com/zack-bitcoin/amoveo/tree/masterother_blockchains/avalanche.md
+[my review of avalanche](/other_blockchains/avalanche.md)
 
 bloxroute
 ========

--- a/other_blockchains/Emin_Gun_Sirer.md
+++ b/other_blockchains/Emin_Gun_Sirer.md
@@ -42,7 +42,7 @@ Emin claims that the bitcoin ng strategy accomplishes these goals:
 So, if bitcoin ng accomplished all the goals it set out to accomplish, it would allow bitcoin to process around 100x more txs per second, and it would take 100x longer to sync bitcoin blocks.
 Since it only scales tx throughput, it doesn't scale our ability to sync with the network. So even if it works how it is supposed to, it is basically worthless for scalability.
 
-Here I have a chart of scaling strategies that actually accomplish scale the blockchain by reducing the bandwidth requirement for syncing: other_blockchains/sharding.md
+Here I have a chart of scaling strategies that actually accomplish scale the blockchain by reducing the bandwidth requirement for syncing: [sharding.md](/other_blockchains/sharding.md)
 
 
 Why it does not have faster finality.

--- a/other_blockchains/RCO.md
+++ b/other_blockchains/RCO.md
@@ -17,7 +17,7 @@ This is a call for volunteers who are willing to put their money at risk to help
 Important Features
 ============
 
-We can do an RCO against any blockchain that is vulnerable to soft fork attacks. For example, [any proof-of-stake blockchain](other_blockchains/proof_of_stake.md)
+We can do an RCO against any blockchain that is vulnerable to soft fork attacks. For example, [any proof-of-stake blockchain](/other_blockchains/proof_of_stake.md)
 
 If we do an RCO on a blockchain, Cardano for example, then people who donate to the RCO will receive real ADA upon the mission's success. ADA that are identical to the rest on Cardano, and fungible with any other on Cardano. So if you are sad that you didn't get to participate in Cardano's ICO, this is your second chance.
 

--- a/other_blockchains/algorand.md
+++ b/other_blockchains/algorand.md
@@ -3,7 +3,7 @@ Algorand Review
 
 Algorand is a PoS blockchain consensus protocol. Here is the paper describing its design https://algorandcom.cdn.prismic.io/algorandcom%2Fece77f38-75b3-44de-bc7f-805f0e53a8d9_theoretical.pdf
 
-I have attempted to show that proof of stake is impossible other_blockchains/proof_of_stake.md
+I have attempted to show that proof of stake is impossible [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 So the goal of this paper is to use what I have learned about PoS, and to see if Algorand is a counter-example of my conclusions, or if I can show that Algorand is not secure.
 

--- a/other_blockchains/avalanche.md
+++ b/other_blockchains/avalanche.md
@@ -26,7 +26,7 @@ Assuming 100% of users behave honestly, does Avalanche work?
 
 Assuming that 100% of the users of Avalanche participate honestly, this is a kind of voting protocol where each user's influence over the outcome is proportional to how much stake they control in the system.
 
-Voting can never work in blockchains: design/voting_in_blockchains.md
+[Voting can never work in blockchains](/design/voting_in_blockchains.md)
 
 So Avalanche is level 4 vulnerable to soft fork bribery attacks, even if 100% of the users follow the rules 100% honestly. So Avalanche is worse than centralized alternatives, even if 100% of users are honest.
 

--- a/other_blockchains/avalanche.md
+++ b/other_blockchains/avalanche.md
@@ -47,4 +47,4 @@ So Avalanche is insecure like a voting protocol, but it is even worse because it
 More reading on this topic
 ==========
 
-Here is a paper showing that all PoS blockchains are vulnerable to soft fork bribery attacks other_blockchains/proof_of_stake.md
+Here is a paper showing that all PoS blockchains are vulnerable to soft fork bribery attacks [proof_of_stake.md](/other_blockchains/proof_of_stake.md)

--- a/other_blockchains/bitcoin.md
+++ b/other_blockchains/bitcoin.md
@@ -153,4 +153,4 @@ explains: 1, 2, 3
 
 The crabs in a bucket model breaks down if ever there is one individual who has physical control over the majority of hashpower. Since an individual is always able to coordinate with himself, there is no way to prevent him from taking control of the consensus. An attacker with physical control of the majority of hashpower could steal any BTC, and change any consensus rules that define bitcoin.
 
-Crabs in a bucket model is very un-popular with PoS blockchain communities, since we can use this model to show that PoS can not work other_blockchains/proof_of_stake.md
+Crabs in a bucket model is very un-popular with PoS blockchain communities, since we can use this model to show that PoS can not work [proof_of_stake.md](/other_blockchains/proof_of_stake.md)

--- a/other_blockchains/cosmos.md
+++ b/other_blockchains/cosmos.md
@@ -1,7 +1,7 @@
 Cosmos
 =======
 
-Recently it was discovered that proof-of-stake cannot be a secure consensus mechanism. other_blockchains/proof_of_stake.md
+Recently it was discovered that proof-of-stake cannot be a secure consensus mechanism. [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 Cosmos is one of the most popular PoS blockchains.
 

--- a/other_blockchains/decred.md
+++ b/other_blockchains/decred.md
@@ -9,7 +9,7 @@ Documentation includes expired data and is not searchable.
 Devs would respond "dyor" to even the most basic questions about how Decred works.
 
 
-Here is a document that explores the capabilities of pow/pos hybrid designs in general: other_blockchains/pow_pos_hybrid.md
+Here is a document that explores the capabilities of pow/pos hybrid designs in general: [pow_pos_hybrid.md](/other_blockchains/pow_pos_hybrid.md)
 
 https://docs.decred.org/proof-of-stake/overview/ Looking at this page.
 At the top of that page, they listed 5 reasons that they incorporate PoS elements into their blockchain. Some of these reasons show flaws in the design.

--- a/other_blockchains/ethereum_casper_ffg.md
+++ b/other_blockchains/ethereum_casper_ffg.md
@@ -1,7 +1,7 @@
 Review of Ethereum Casper FFG
 ==========
 
-I wrote a paper about why all PoS blockchains are vulnerable to soft fork bribery attacks other_blockchains/proof_of_stake.md
+I wrote a paper about why all PoS blockchains are vulnerable to soft fork bribery attacks [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 In general, any attempt to recover from a soft fork bribery attack will have one of these shortcomings:
 1) we undo the history that occured during the soft fork bribery attack, enabling the attacker to do double-spends between that version of history, and the new version.

--- a/other_blockchains/iota.md
+++ b/other_blockchains/iota.md
@@ -26,4 +26,4 @@ in the second paragraph:
 There is no reason for us to waste time studying centralized services like the current version of IOTA.
 
 Looks like they are adding a subcurrency called "mana" for a voting based consensus mechanism. I have already written a lot about why that strategy can not work.  [voting in blockchains](design/voting_in_blockchains.md)
-[why proof of stake does not work](other_blockchains/proof_of_stake.md)
+[why proof of stake does not work](/other_blockchains/proof_of_stake.md)

--- a/other_blockchains/iota.md
+++ b/other_blockchains/iota.md
@@ -3,7 +3,7 @@ Iota Review
 
 Iota descripton from their team: https://assets.ctfassets.net/r1dr6vzfxhev/2t4uxvsIqk0EUau6g2sw0g/45eae33637ca92f85dd9f4a3a218e1ec/iota1_4_3.pdf
 
-This review is applying the techniques from this paper: other_blockchains/proof_of_stake.md
+This review is applying the techniques from this paper: [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 The pow half of Iota's pow/pos hybrid model is not being used for consensus. It is cheap to get >50% hashpower, but having >50% hashpower wont matter. It is just an anti-spam feature so that the total number of valid messages that a full node would have to consider has some reasonable bounds.
 

--- a/other_blockchains/nyzo.md
+++ b/other_blockchains/nyzo.md
@@ -99,7 +99,7 @@ Attacks
 Soft fork bribery attacks
 ==========
 
-This section applying the attack described in this paper other_blockchains/proof_of_stake.md to Nyzo.
+This section applying the attack described in this paper [proof_of_stake.md](/other_blockchains/proof_of_stake.md) to Nyzo.
 
 An attacker can bribe the voters to use the validator-vote-slashing mechanism to kick out any arbitrary validator that they dislike.
 If the attacker keeps doing this, eventually they can control the majority of the validator pool.

--- a/other_blockchains/optimistic_rollups.md
+++ b/other_blockchains/optimistic_rollups.md
@@ -14,10 +14,10 @@ The goal of these efforts is to try and enable scalable stablecoin payments.
 Scalability analysis
 ========
 
-[estimating the cost of fraud proofs in optimistic rollup](other_blockchains/optimistic_rollups_fraud_proof_cost.md) Fraud proof security costs the same amount per tx, no matter how many txs are being processed per second.
+[estimating the cost of fraud proofs in optimistic rollup](/other_blockchains/optimistic_rollups_fraud_proof_cost.md) Fraud proof security costs the same amount per tx, no matter how many txs are being processed per second.
 This means that there is some lower limit cost per tx, and the fee will never be below that limit.
 
-[estimating the cost of attacking a sidechain inside optimistic rollup](other_blockchains/optimistic_rollups_sidechain_attack.md)
+[estimating the cost of attacking a sidechain inside optimistic rollup](/other_blockchains/optimistic_rollups_sidechain_attack.md)
 The amount of stake that needs to be locked up by sidechain validators is proportional to (rate of tx production)^(3/2).
 This means that the lower limit fee cost keeps getting more expensive as more people join the network.
 

--- a/other_blockchains/optimistic_rollups_fraud_proof_cost.md
+++ b/other_blockchains/optimistic_rollups_fraud_proof_cost.md
@@ -1,7 +1,7 @@
 Optimistic Rollups Fraud Proof Cost Estimate
 ===========
 
-[optimistic rollup review home](other_blockchains/optimistic_rollups.md)
+[optimistic rollup review home](/other_blockchains/optimistic_rollups.md)
 
 
 

--- a/other_blockchains/optimistic_rollups_sidechain_attack.md
+++ b/other_blockchains/optimistic_rollups_sidechain_attack.md
@@ -1,7 +1,7 @@
 Optimistic Rollups sidechain attack
 ==========
 
-[optimistic rollup review home](other_blockchains/optimistic_rollups.md)
+[optimistic rollup review home](/other_blockchains/optimistic_rollups.md)
 
 This is an attempt to show that if optimistic rollup scales worse than linearly.
 If you increase the rate of tx production, the fee per tx necessarily increases.
@@ -24,7 +24,7 @@ Lets suppose that more than one person has permission to publish a sidechain blo
 
 A sidechain block needs to hold many txs, but an attacker can build a contradictory sidechain block that only contains 1 tx, and he can get his small contradictory block inserted in front of the large block.
 
-So the cost to the attacker is the cost of publishing a single tx into the available consensus state. And the destruction caused by the attack is proportional to the size of an average sidechain block, which we know from [fraud proof analysis](other_blockchains/optimistic_rollups_fraud_proof_cost.md) must be at least O(sqrt(sqrt(total # of txs in the available consensus space))).
+So the cost to the attacker is the cost of publishing a single tx into the available consensus state. And the destruction caused by the attack is proportional to the size of an average sidechain block, which we know from [fraud proof analysis](/other_blockchains/optimistic_rollups_fraud_proof_cost.md) must be at least O(sqrt(sqrt(total # of txs in the available consensus space))).
 Since the destruction is bigger than the cost of the attack, this would be a level 3 attack. So that means it would not be secure to have a sidechain where more than one person has permission to publish blocks.
 
 So that means that for any moment in time, there needs to be someone, or some group of people with exclusive permission to make sidechain blocks. They are the leadership for that sidechain.

--- a/other_blockchains/optimistic_rollups_sidechain_attack.md
+++ b/other_blockchains/optimistic_rollups_sidechain_attack.md
@@ -32,7 +32,7 @@ So that means that for any moment in time, there needs to be someone, or some gr
 Permanent leadership does not work
 ============
 
-if the leadership for any one sidechain was permanent, then that sidechain would be vulnerable to soft fork bribery attacks. other_blockchains/proof_of_stake.md
+if the leadership for any one sidechain was permanent, then that sidechain would be vulnerable to soft fork bribery attacks. [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 As long as the leadership is being swapped out regularly, and you are unable to predict who the next leaders will be, and it is infeasible to bribe all the validators for all the shards all at once, then bribing is ineffective. Because you don't know who you would need to lock into a contract to have the guarantees you need to start executing the attack.
 

--- a/other_blockchains/ouroboros.md
+++ b/other_blockchains/ouroboros.md
@@ -3,11 +3,11 @@ Ouroboros Review
 
 Ouroboros is a proof of stake type blockchain consensus mechanism. Here is the paper describing it https://eprint.iacr.org/2016/889.pdf
 
-I have written a general paper about why [PoS is not possible](other_blockchains/proof_of_stake.md)
+I have written a general paper about why [PoS is not possible](/other_blockchains/proof_of_stake.md)
 
 The goal of this paper is to analyze ouroboros to see if they have managed to prove me wrong. I will try to show that Ouroboros can not be secure.
 
-[Here people attempt to show that the attack in this paper wont work](other_blockchains/the_defence_of_pos.md)
+[Here people attempt to show that the attack in this paper wont work](/other_blockchains/the_defence_of_pos.md)
 
 Others have written about the myth that PoS is cheaper than PoW, so I will just [link to their work on the subject](http://www.truthcoin.info/blog/pow-cheapest/)
 

--- a/other_blockchains/ouroboros.md
+++ b/other_blockchains/ouroboros.md
@@ -31,7 +31,7 @@ The process of proving the security of a blockchain has these steps:
 Step (2) is the part we can prove in an undeniable mathematical way.
 
 Step (1) is a controversial topic in blockchain today.
-For example, we cannot even agree on which security model is securing bitcoin other_blockchains/bitcoin.md
+For example, we cannot even agree on which security model is securing bitcoin [bitcoin.md](/other_blockchains/bitcoin.md)
 
 In this paper, I will be trying to explain what security model Ouroboros is based upon, and I will try to show that their security model is not good enough to secure a cryptocurrency.
 

--- a/other_blockchains/pos_organizer.md
+++ b/other_blockchains/pos_organizer.md
@@ -3,7 +3,7 @@ Proof of stake links
 
 [Why I think PoS does not work](/other_blockchains/proof_of_stake.md)
 
-[A plan on how to actually do this attack](other_blockchains/RCO.md)
+[A plan on how to actually do this attack](/other_blockchains/RCO.md)
 
 [Why others think that PoS does work](/other_blockchains/the_defence_of_pos.md)
 

--- a/other_blockchains/pos_organizer.md
+++ b/other_blockchains/pos_organizer.md
@@ -1,21 +1,21 @@
 Proof of stake links
 ===========
 
-[Why I think PoS does not work](other_blockchains/proof_of_stake.md)
+[Why I think PoS does not work](/other_blockchains/proof_of_stake.md)
 
 [A plan on how to actually do this attack](other_blockchains/RCO.md)
 
-[Why others think that PoS does work](other_blockchains/the_defence_of_pos.md)
+[Why others think that PoS does work](/other_blockchains/the_defence_of_pos.md)
 
-[Cosmos](other_blockchains/cosmos.md)
+[Cosmos](/other_blockchains/cosmos.md)
 
-[Cardano](other_blockchains/ouroboros.md)
+[Cardano](/other_blockchains/ouroboros.md)
 
-[Algorand](other_blockchains/algorand.md)
+[Algorand](/other_blockchains/algorand.md)
 
-[Nyzo](other_blockchains/nyzo.md)
+[Nyzo](/other_blockchains/nyzo.md)
 
-[IOTA](other_blockchains/iota.md)
+[IOTA](/other_blockchains/iota.md)
 
-[Ethereum Casper FFG](other_blockchains/ethereum_casper_ffg.md)
+[Ethereum Casper FFG](/other_blockchains/ethereum_casper_ffg.md)
 

--- a/other_blockchains/rough_draft.md
+++ b/other_blockchains/rough_draft.md
@@ -52,7 +52,7 @@ consensus-creating state-machine.
 
 Since they don't describe a PoS mechanism, there is nothing for me to review.
 
-Instead I will link to a paper I have written that shows proof-of-stake is not a solvable problem other_blockchains/proof_of_stake.md
+Instead I will link to a paper I have written that shows proof-of-stake is not a solvable problem [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 
 Governance

--- a/other_blockchains/sharding.md
+++ b/other_blockchains/sharding.md
@@ -40,7 +40,7 @@ Sharding Plans
 
 * optimistic roll-up. https://arxiv.org/pdf/1904.06441.pdf  With optimistic roll-up we keep the history on-chain, but we move all processing of editable state onto side-chains. Miners pay a safety deposit when they publish a block. If anyone can show that a block improperly processed a transaction, they can destroy half the safety deposit and win the rest as a reward.
 
-[My review of optimistic rollup](other_blockchains/optimistic_rollups.md)
+[My review of optimistic rollup](/other_blockchains/optimistic_rollups.md)
 
 [Vitalik talking about optimistic rollup](https://twitter.com/Shaughnessy119/status/1187390153662316544?s=20) it looks like this is the plan for Eth2.0
 

--- a/other_blockchains/spectreDAG.md
+++ b/other_blockchains/spectreDAG.md
@@ -73,6 +73,6 @@ But they don't go very deep into details.
 
 But it seems like they are making an assumption that the majority of miners will honestly report about which tx they had seen first.
 
-Assuming that miners will honestly report which tx they had seen first, even if there is not financial incentive to enforce them to report honestly, that is a vulnerability based on my model of trust theory https://github.com/zack-bitcoin/amoveo/blob/master/docs/basics/trust_theory.md
+Assuming that miners will honestly report which tx they had seen first, even if there is not financial incentive to enforce them to report honestly, that is a vulnerability based on my model of trust theory https://github.com/zack-bitcoin/amoveo-docs/blob/master/basics/trust_theory.md
 If the cost to execute an attack is zero, then it is not secure.
 

--- a/other_blockchains/synthetix.md
+++ b/other_blockchains/synthetix.md
@@ -42,5 +42,5 @@ Synthetix has on-chain exchanges for each asset they support. Miners can re-orde
 The oracle
 ===========
 
-They use [chainlink. Chainlink is not secure.](other_blockchains/chainlink.md)
+They use [chainlink. Chainlink is not secure.](/other_blockchains/chainlink.md)
 

--- a/other_blockchains/the_defence_of_pos.md
+++ b/other_blockchains/the_defence_of_pos.md
@@ -1,7 +1,7 @@
 The Defense of PoS
 ========
 
-I wrote [the PoS paper](other_blockchains/proof_of_stake.md) as an attempt at a general argument to show that PoS is not possible.
+I wrote [the PoS paper](/other_blockchains/proof_of_stake.md) as an attempt at a general argument to show that PoS is not possible.
 
 I shared the PoS paper with many people who have a vested interest in PoS technology, and I have received different responses from them. The goal of this paper is to collect the various arguments in favor of PoS together in one place, so we can see why different people believe PoS can still work.
 
@@ -164,7 +164,7 @@ Lion's argument is that PoS is game-theoretically the same as PoW in bitcoin for
 
 This is basically the same as Vitalik's arguments in favor of PoS from January 2015 in his [P+epsilon paper](https://blog.ethereum.org/2015/01/28/p-epsilon-attack/) in the "Further Consequences" section.
 
-I explain why this bribery attack can not be done against proof of work in [this paper](other_blockchains/proof_of_stake.md) in the section "Censorship can be good".
+I explain why this bribery attack can not be done against proof of work in [this paper](/other_blockchains/proof_of_stake.md) in the section "Censorship can be good".
 
 sebastiengllmt
 ========

--- a/other_blockchains/veriblock.md
+++ b/other_blockchains/veriblock.md
@@ -32,4 +32,4 @@ If 99% of bitcoin miners include headers for both sides of a veriblock fork, and
 Conclusion
 =======
 
-Veriblock sidechains are a similar design as drivechain. They have the same vulnerabilities to soft fork bribery attacks. other_blockchains/drivechain.md
+Veriblock sidechains are a similar design as drivechain. They have the same vulnerabilities to soft fork bribery attacks. [drivechain.md](/other_blockchains/drivechain.md)

--- a/other_blockchains/zano.md
+++ b/other_blockchains/zano.md
@@ -7,13 +7,13 @@ The Zano white paper is very high quality documentation. Possibly the best white
 The graphs are great, the explanations are clear.
 Accurately communicating your work is critical for others to be able to review it and give helpful advice. This is where Zano shines.
 
-Here is a general proof that PoW/PoS hybrid protocols are impossible: other_blockchains/pow_pos_hybrid.md
+Here is a general proof that PoW/PoS hybrid protocols are impossible: [pow_pos_hybrid.md](/other_blockchains/pow_pos_hybrid.md)
 
 
 Privacy and Bribery
 ========
 
-In general, proof of stake type mechanisms are vulnerable to bribery other_blockchains/proof_of_stake.md
+In general, proof of stake type mechanisms are vulnerable to bribery [proof_of_stake.md](/other_blockchains/proof_of_stake.md)
 
 The optimal way to do this in Zano is by paying validators to move all their money to a different address, and to sell you a copy of their now empty private key, which was a valid private key a couple hours earlier.
 


### PR DESCRIPTION
- added links to docs that were implicitly referenced in text. e.g. `see this example: other_blockchains/example.md` becomes `see this example: [example.md](/other_blockchains/example.md)`
- fixed links to sibling docs that used relative paths instead of absolute paths (github is nice about absolute paths and converting them to work well with repos); `[...](other_blockchains/example.md)` becomes `[...](/other_blockchains/example.md)`
- fixed some links that were broken b/c of github URL stuff or referring to old location
- added a link in Emin_Gun_sirer.md manually that was github-url related.

example from PR repo/branch to see how it works in github: https://github.com/XertroV/amoveo-docs/blob/xmaster/other_blockchains/pos_organizer.md

I wasn't sure if you used these md files as source for building a static site (which might require URLs that don't work on github's code view), but I couldn't find anything on google searching for quotes, so I guess that these changes are good.

NB: the first two commits contain the commands I ran to produce the changes; it might be easy to replicate this PR for docs in other folders if they have links that are also broken in the same way.